### PR TITLE
修复一些链接问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,137 +4,134 @@
 
 ### 2025年9月
 
-- 第66期：[2025年8月30日-2025年9月6日](https://github.com/xuanli199/weekly/blob/main/docs/66.md)
+- 第66期：[2025年8月30日-2025年9月6日](docs/66.md)
 
 ### 2025年8月
 
-- 第65期：[2025年8月23日-2025年8月30日](https://github.com/xuanli199/weekly/blob/main/docs/65.md)
+- 第65期：[2025年8月23日-2025年8月30日](docs/65.md)
 
-- 第64期：[2025年8月16日-2025年8月23日](https://github.com/xuanli199/weekly/blob/main/docs/64.md)
+- 第64期：[2025年8月16日-2025年8月23日](docs/64.md)
 
-- 第63期：[2025年8月9日-2025年8月16日](https://github.com/xuanli199/weekly/blob/main/docs/63.md)
+- 第63期：[2025年8月9日-2025年8月16日](docs/63.md)
 
-- 第62期：[2025年8月2日-2025年8月9日](https://github.com/xuanli199/weekly/blob/main/docs/62.md)
+- 第62期：[2025年8月2日-2025年8月9日](docs/62.md)
 
-- 第61期：[2025年7月26日-2025年8月2日](https://github.com/xuanli199/weekly/blob/main/docs/61.md)
+- 第61期：[2025年7月26日-2025年8月2日](docs/61.md)
 
 ### 2025年7月
 
-- 第60期：[2025年7月19日-2025年7月26日](https://github.com/xuanli199/weekly/blob/main/docs/60.md)
+- 第60期：[2025年7月19日-2025年7月26日](docs/60.md)
 
-- 第59期：[2025年7月12日-2025年7月19日](https://github.com/xuanli199/weekly/blob/main/docs/59.md)
+- 第59期：[2025年7月12日-2025年7月19日](docs/59.md)
 
-- 第58期：[2025年7月5日-2025年7月12日](https://github.com/xuanli199/weekly/blob/main/docs/58.md)
+- 第58期：[2025年7月5日-2025年7月12日](docs/58.md)
 
-- 第57期：[2025年6月28日-2025年7月5日](https://github.com/xuanli199/weekly/blob/main/docs/57.md)
+- 第57期：[2025年6月28日-2025年7月5日](docs/57.md)
 
 ### 2025年6月
 
-- 第56期：[2025年6月21日-2025年6月28日](https://github.com/xuanli199/weekly/blob/main/docs/56.md)
+- 第56期：[2025年6月21日-2025年6月28日](docs/56.md)
 
-- 第55期：[2025年6月14日-2025年6月21日](https://github.com/xuanli199/weekly/blob/main/docs/55.md)
+- 第55期：[2025年6月14日-2025年6月21日](docs/55.md)
 
-- 第54期：[2025年6月7日-2025年6月14日](https://github.com/xuanli199/weekly/blob/main/docs/54.md)
+- 第54期：[2025年6月7日-2025年6月14日](docs/54.md)
 
-- 第53期：[2025年5月31日-2025年6月7日](https://github.com/xuanli199/weekly/blob/main/docs/53.md)
+- 第53期：[2025年5月31日-2025年6月7日](docs/53.md)
 
 ### 2025年5月
 
-- 第52期：[2025年5月24日-2025年5月31日](https://github.com/xuanli199/weekly/blob/main/docs/52.md)
+- 第52期：[2025年5月24日-2025年5月31日](docs/52.md)
 
-- 第51期：[2025年5月17日-2025年5月24日](https://github.com/xuanli199/weekly/blob/main/docs/51.md)
+- 第51期：[2025年5月17日-2025年5月24日](docs/51.md)
 
-- 第50期：[2025年5月10日-2025年5月17日](https://github.com/xuanli199/weekly/blob/main/docs/50.md)
+- 第50期：[2025年5月10日-2025年5月17日](docs/50.md)
 
-- 第49期：[2025年5月3日-2025年5月10日](https://github.com/xuanli199/weekly/blob/main/docs/49.md)
+- 第49期：[2025年5月3日-2025年5月10日](docs/49.md)
 
-- 第48期：[2025年4月26日-2025年5月3日](https://github.com/xuanli199/weekly/blob/main/docs/48.md)
+- 第48期：[2025年4月26日-2025年5月3日](docs/48.md)
 
 ### 2025年4月
 
+- 第47期：[2025年4月19日-2025年4月26日](docs/47.md)
 
-- 第47期：[2025年4月19日-2025年4月26日](https://github.com/xuanli199/weekly/blob/main/docs/47.md)
+- 第46期：[2025年4月12日-2025年4月19日](docs/46.md)
 
-- 第46期：[2025年4月12日-2025年4月19日](https://github.com/xuanli199/weekly/blob/main/docs/46.md)
+- 第45期：[2025年4月5日-2025年4月12日](docs/45.md)
 
-- 第45期：[2025年4月5日-2025年4月12日](https://github.com/xuanli199/weekly/blob/main/docs/45.md)
-
-- 第44期：[2025年3月29日-2025年4月5日](https://github.com/xuanli199/weekly/blob/main/docs/44.md)
+- 第44期：[2025年3月29日-2025年4月5日](docs/44.md)
 
 ### 2025年3月
 
+- 第43期：[2025年3月22日-2025年3月29日](docs/43.md)
 
-- 第43期：[2025年3月22日-2025年3月29日](https://github.com/xuanli199/weekly/blob/main/docs/43.md)
+- 第42期：[2025年3月15日-2025年3月22日](docs/42.md)
 
-- 第42期：[2025年3月15日-2025年3月22日](https://github.com/xuanli199/weekly/blob/main/docs/42.md)
-
-- 第41期：[2025年3月8日-2025年3月15日](https://github.com/xuanli199/weekly/blob/main/docs/41.md)
-- 第40期：[2025年3月1日-2025年3月8日](https://github.com/xuanli199/weekly/blob/main/docs/40.md)
+- 第41期：[2025年3月8日-2025年3月15日](docs/41.md)
+- 第40期：[2025年3月1日-2025年3月8日](docs/40.md)
 
 ### 2025年2月
 
-- 第39期：[2025年2月22日-2025年3月1日](https://github.com/xuanli199/weekly/blob/main/docs/39.md)
+- 第39期：[2025年2月22日-2025年3月1日](docs/39.md)
 
-- 第38期：[2025年2月15日-2025年2月22日](https://github.com/xuanli199/weekly/blob/main/docs/38.md)
-- 第37期：[2025年2月8日-2025年2月15日](https://github.com/xuanli199/weekly/blob/main/docs/37.md)
-- 第36期：[2025年2月1日-2025年2月8日](https://github.com/xuanli199/weekly/blob/main/docs/36.md)
-- 第35期：[2025年1月25日-2025年2月1日](https://github.com/xuanli199/weekly/blob/main/docs/35.md)
+- 第38期：[2025年2月15日-2025年2月22日](docs/38.md)
+- 第37期：[2025年2月8日-2025年2月15日](docs/37.md)
+- 第36期：[2025年2月1日-2025年2月8日](docs/36.md)
+- 第35期：[2025年1月25日-2025年2月1日](docs/35.md)
 
 ### 2025年1月
 
-- 第34期：[2025年1月18日-2025年1月25日](https://github.com/xuanli199/weekly/blob/main/docs/34.md)
-- 第33期：[2025年1月11日-2025年1月18日](https://github.com/xuanli199/weekly/blob/main/docs/33.md)
-- 第32期：[2025年1月4日-2024年1月11日](https://github.com/xuanli199/weekly/blob/main/docs/32.md)
-- 第31期：[2024年12月28日-2025年1月4日](https://github.com/xuanli199/weekly/blob/main/docs/31.md)
+- 第34期：[2025年1月18日-2025年1月25日](docs/34.md)
+- 第33期：[2025年1月11日-2025年1月18日](docs/33.md)
+- 第32期：[2025年1月4日-2024年1月11日](docs/32.md)
+- 第31期：[2024年12月28日-2025年1月4日](docs/31.md)
 
 ### 2024年12月
 
-- 第30期：[2024年12月21日-2024年12月28日](https://github.com/xuanli199/weekly/blob/main/docs/30.md)
-- 第29期：[2024年12月14日-2024年12月21日](https://github.com/xuanli199/weekly/blob/main/docs/29.md)
-- 第28期：[2024年12月7日-2024年12月14日](https://github.com/xuanli199/weekly/blob/main/docs/28.md)
-- 第27期：[2024年11月30日-2024年12月7日](https://github.com/xuanli199/weekly/blob/main/docs/27.md)
+- 第30期：[2024年12月21日-2024年12月28日](docs/30.md)
+- 第29期：[2024年12月14日-2024年12月21日](docs/29.md)
+- 第28期：[2024年12月7日-2024年12月14日](docs/28.md)
+- 第27期：[2024年11月30日-2024年12月7日](docs/27.md)
 
 ### 2024年11月
 
-- 第26期：[2024年11月16日-2024年11月23日](https://github.com/xuanli199/weekly/blob/main/docs/26.md)
-- 第25期：[2024年11月16日-2024年11月23日](https://github.com/xuanli199/weekly/blob/main/docs/25.md)
-- 第24期：[2024年11月9日-2024年11月16日](https://github.com/xuanli199/weekly/blob/main/docs/24.md)
-- 第23期：[2024年11月2日-2024年11月9日](https://github.com/xuanli199/weekly/blob/main/docs/23.md)
-- 第22期：[2024年10月26日-2024年11月2日](https://github.com/xuanli199/weekly/blob/main/docs/22.md)
+- 第26期：[2024年11月16日-2024年11月23日](docs/26.md)
+- 第25期：[2024年11月16日-2024年11月23日](docs/25.md)
+- 第24期：[2024年11月9日-2024年11月16日](docs/24.md)
+- 第23期：[2024年11月2日-2024年11月9日](docs/23.md)
+- 第22期：[2024年10月26日-2024年11月2日](docs/22.md)
 
 ### 2024年10月
 
-- 第21期：[2024年10月19日-2024年10月26日](https://github.com/xuanli199/weekly/blob/main/docs/21.md)
-- 第20期：[2024年10月12日-2024年10月19日](https://github.com/xuanli199/weekly/blob/main/docs/20.md)
-- 第19期：[2024年10月5日-2024年10月12日](https://github.com/xuanli199/weekly/blob/main/docs/19.md)
-- 第18期：[2024年9月28日-2024年10月5日](https://github.com/xuanli199/weekly/blob/main/docs/18.md)
+- 第21期：[2024年10月19日-2024年10月26日](docs/21.md)
+- 第20期：[2024年10月12日-2024年10月19日](docs/20.md)
+- 第19期：[2024年10月5日-2024年10月12日](docs/19.md)
+- 第18期：[2024年9月28日-2024年10月5日](docs/18.md)
 
 ### 2024年9月
 
-- 第17期：[2024年9月21日-2024年9月28日](https://github.com/xuanli199/weekly/blob/main/docs/17.md)
-- 第16期：[2024年9月14日-2024年9月21日](https://github.com/xuanli199/weekly/blob/main/docs/16.md)
-- 第15期：[2024年9月7日-2024年9月14日](https://github.com/xuanli199/weekly/blob/main/docs/15.md)
-- 第14期：[2024年8月24日-2024年8月31日](https://github.com/xuanli199/weekly/blob/main/docs/14.md)
+- 第17期：[2024年9月21日-2024年9月28日](docs/17.md)
+- 第16期：[2024年9月14日-2024年9月21日](docs/16.md)
+- 第15期：[2024年9月7日-2024年9月14日](docs/15.md)
+- 第14期：[2024年8月24日-2024年8月31日](docs/14.md)
 
 ### 2024年8月
 
-- 第13期：[2024年8月24日-2024年8月31日](https://github.com/xuanli199/weekly/blob/main/docs/13.md)
-- 第12期：[2024年8月17日-2024年8月24日](https://github.com/xuanli199/weekly/blob/main/docs/12.md)
-- 第11期：[2024年8月10日-2024年8月17日](https://github.com/xuanli199/weekly/blob/main/docs/11.md)
-- 第十期：[2024年8月3日-2024年8月10日](https://github.com/xuanli199/weekly/blob/main/docs/10.md)
+- 第13期：[2024年8月24日-2024年8月31日](docs/13.md)
+- 第12期：[2024年8月17日-2024年8月24日](docs/12.md)
+- 第11期：[2024年8月10日-2024年8月17日](docs/11.md)
+- 第十期：[2024年8月3日-2024年8月10日](docs/10.md)
 
 ### 2024年7月
 
-- 第九期：[2024年7月27日-2024年8月3日](https://github.com/xuanli199/weekly/blob/main/docs/09.md)
-- 第八期：[2024年7月20日-2024年7月27日](https://github.com/xuanli199/weekly/blob/main/docs/08.md)
-- 第七期：[2024年7月13日-2024年7月20日](https://github.com/xuanli199/weekly/blob/main/docs/07.md)
-- 第六期：[2024年7月6日-2024年7月13日](https://github.com/xuanli199/weekly/blob/main/docs/06.md)
+- 第九期：[2024年7月27日-2024年8月3日](docs/09.md)
+- 第八期：[2024年7月20日-2024年7月27日](docs/08.md)
+- 第七期：[2024年7月13日-2024年7月20日](docs/07.md)
+- 第六期：[2024年7月6日-2024年7月13日](docs/06.md)
 
 ### 2024年6月
 
-- 第五期：[2024年6月29日-2024年7月6日](https://github.com/xuanli199/weekly/blob/main/docs/05.md)
-- 第四期：[2024年6月22日-2024年6月29日](https://github.com/xuanli199/weekly/blob/main/docs/04.md)
-- 第三期：[2024年6月15日-2024年6月22日](https://github.com/xuanli199/weekly/blob/main/docs/03.md)
+- 第五期：[2024年6月29日-2024年7月6日](docs/05.md)
+- 第四期：[2024年6月22日-2024年6月29日](docs/04.md)
+- 第三期：[2024年6月15日-2024年6月22日](docs/03.md)
 - 第二期：2024年6月9日-2024年6月16日 暂无内容
-- 第一期：[2024年6月3日-2024年6月9日](https://github.com/xuanli199/weekly/blob/main/docs/01.md)
-  
+- 第一期：[2024年6月3日-2024年6月9日](docs/01.md)

--- a/docs/04.md
+++ b/docs/04.md
@@ -44,9 +44,9 @@ Winlator 是一个在手机上的 Windows 模拟器，我之前已经详细讲�
 
 [termux：https://termux.dev/cn/index.html](https://termux.dev/cn/index.html)
 
-[Winlator：https://winlator.org/]([https://winlator.org/](https://winlator.org/))
+[Winlator：https://winlator.org/](https://winlator.org/)
 
-[爱吾游戏盒：https://m.25game.com/]([https://m.25game.com/](https://m.25game.com/))
+[爱吾游戏盒：https://m.25game.com/](https://m.25game.com/)
 
 [小马模拟器：http://www.ponyemu.com/index_m.html](http://www.ponyemu.com/index_m.html)
 


### PR DESCRIPTION
README.md 写死 Github 链接了。在 Github 上没有问题，但在本地的markdown阅读器上，点击链接后不会跳转到本地的文件上，而是打开 Github。
```diff
- - 第66期：[2025年8月30日-2025年9月6日](https://github.com/xuanli199/weekly/blob/main/docs/66.md)
+ - 第66期：[2025年8月30日-2025年9月6日](docs/66.md)
```
这样才是正确的写法。当然这么写 Github 也能认出来，见：https://github.com/FBIKdot/weekly/tree/main 。

以及第四期有链接书写错误。见 https://github.com/xuanli199/weekly/pull/20/commits/d8bdbc9a447bc8c336e629bf99d843c80530d4b6